### PR TITLE
Properly start IISExpress for tests

### DIFF
--- a/src/MVC.Courses.Test.Integration/IisServerTestBase.cs
+++ b/src/MVC.Courses.Test.Integration/IisServerTestBase.cs
@@ -4,8 +4,7 @@ using System.IO;
 using NUnit.Framework;
 
 namespace MVC.Courses.Test.Integration
-{
-    [SetUpFixture]
+{   
     public abstract class IisServerTestBase
     {
         const int IisPort = 2042;
@@ -46,16 +45,16 @@ namespace MVC.Courses.Test.Integration
             var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
 
             _iisProcess = new Process();
-            _iisProcess.StartInfo.FileName = programFiles + @"\IIS Express\iisexpress.exe";
-            _iisProcess.StartInfo.Arguments = string.Format("/path:\"{0}\" /port:{1}", applicationPath, IisPort);
+            _iisProcess.StartInfo.FileName = Path.Combine(programFiles,"IIS Express","iisexpress.exe");
+            _iisProcess.StartInfo.Arguments = $"/path:\"{applicationPath}\" /port:{IisPort}";
             _iisProcess.Start();
         }
 
         protected virtual string GetApplicationPath(string applicationName)
         {
-            var solutionFolder =
-                Path.GetDirectoryName(
-                    Path.GetDirectoryName(Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory)));
+            var baseDir = AppDomain.CurrentDomain.BaseDirectory;            
+            var solutionFolder = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..",".."));
+            
             return Path.Combine(solutionFolder, applicationName);
         }
 
@@ -65,7 +64,7 @@ namespace MVC.Courses.Test.Integration
             {
                 relativeUrl = "/" + relativeUrl;
             }
-            return String.Format("http://localhost:{0}/{1}", IisPort, relativeUrl);
+            return $"http://localhost:{IisPort}/{relativeUrl}";
         }
     }
 }

--- a/src/MVC.Courses.Test.Integration/Web/HomeTests.cs
+++ b/src/MVC.Courses.Test.Integration/Web/HomeTests.cs
@@ -18,8 +18,8 @@ namespace MVC.Courses.Test.Integration.Web
         [TestCase]
         public void GiveMeJson_should_return_json()
         {
-            WebDriver.Navigate().GoToUrl(GetAbsoluteUrl("/Home/givemejson?requestObject=headers"));
-            var source = WebDriver.PageSource;
+            WebDriver.Navigate().GoToUrl(GetAbsoluteUrl("/Home/givemejson?requestObject=headers"));            
+            var source = WebDriver.PageSource;                       
             source.ShouldNotBeEmpty();
         }
     }


### PR DESCRIPTION
IISExpress wasn't being started when running the integration tests. The process started, and then subsequently started because it was being pointed at the wrong project. This corrects that command line, as well as some other general boyscouting in the IIS base class.