### PR TITLE
Use visual studio iis

### DIFF
--- a/src/MVC.Courses.Test.Integration/MVC.Courses.Test.Integration.csproj
+++ b/src/MVC.Courses.Test.Integration/MVC.Courses.Test.Integration.csproj
@@ -45,6 +45,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="WebDriver, Version=2.45.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Selenium.WebDriver.PhantomJS.Xplatform.2.45.0.1\lib\net40\WebDriver.dll</HintPath>
     </Reference>


### PR DESCRIPTION
If the Visual Studio debugger has already been used to start the application, defer to that instead of using a new instance of IIS Express. This allows the controllers to be stepped into when running the tests.
